### PR TITLE
php version 5.5 and 5.6 removed from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - hhvm
 


### PR DESCRIPTION
**Problem**
phpunit ^6 is the required dependency of this package which is defined in composer.json file and this phpunit version's has the version requirement of php is ^7. So we the CI is being failed. 

**Solution**
To make it pass and using phpunit ^6, I have removed all other version of php except 7.0 from travis.yml.